### PR TITLE
Update User Agent

### DIFF
--- a/lib/elastic/workplace-search/configuration.rb
+++ b/lib/elastic/workplace-search/configuration.rb
@@ -11,7 +11,6 @@ module Elastic
 
       VALID_OPTIONS_KEYS = [
         :access_token,
-        :user_agent,
         :endpoint
       ].freeze
 
@@ -25,7 +24,6 @@ module Elastic
       def reset
         self.access_token = nil
         self.endpoint = DEFAULT_ENDPOINT
-        self.user_agent = nil
         self
       end
 

--- a/lib/elastic/workplace-search/request.rb
+++ b/lib/elastic/workplace-search/request.rb
@@ -105,12 +105,20 @@ module Elastic
       end
 
       def setup_headers(req)
-        req['User-Agent'] = Elastic::WorkplaceSearch.user_agent if Elastic::WorkplaceSearch.user_agent
+        req['User-Agent'] = request_user_agent
         req['Content-Type'] = 'application/json'
-        req['X-Swiftype-Client'] = CLIENT_NAME
-        req['X-Swiftype-Client-Version'] = CLIENT_VERSION
         req['Authorization'] = "Bearer #{access_token}"
         req
+      end
+
+      def request_user_agent
+        ua = "#{CLIENT_NAME}/#{CLIENT_VERSION}"
+        meta = ["RUBY_VERSION: #{RUBY_VERSION}"]
+        if RbConfig::CONFIG && RbConfig::CONFIG['host_os']
+          meta << "#{RbConfig::CONFIG['host_os'].split('_').first[/[a-z]+/i].downcase} " \
+                  "#{RbConfig::CONFIG['target_cpu']}"
+        end
+        "#{ua} (#{meta.join('; ')})"
       end
 
       def setup_proxy(uri)

--- a/spec/client/request_spec.rb
+++ b/spec/client/request_spec.rb
@@ -7,13 +7,20 @@ describe Elastic::WorkplaceSearch::Client do
   let(:response) { { 'status' => 'ok' } }
   let(:stub_response) { { body: response.to_json } }
   let(:host) { 'http://localhost:3002/api/ws/v1' }
-  let(:access_token) { 'cGUN-vBokevBhhzyA669' }
+  let(:access_token) { 'access_token' }
+  let(:user_agent) do
+    [
+      "#{Elastic::WorkplaceSearch::CLIENT_NAME}/#{Elastic::WorkplaceSearch::VERSION} ",
+      "(RUBY_VERSION: #{RUBY_VERSION}; ",
+      "#{RbConfig::CONFIG['host_os'].split('_').first[/[a-z]+/i].downcase} ",
+      "#{RbConfig::CONFIG['target_cpu']})"
+    ].join
+  end
+
   let(:headers) do
     {
-      'User-Agent' => 'Ruby',
+      'User-Agent' => user_agent,
       'Content-Type' => 'application/json',
-      'X-Swiftype-Client' => Elastic::WorkplaceSearch::CLIENT_NAME,
-      'X-Swiftype-Client-Version' => Elastic::WorkplaceSearch::CLIENT_VERSION,
       'Authorization' => "Bearer #{access_token}"
     }
   end


### PR DESCRIPTION
- Removes `X-Swiftype-Client` and `Version` headers which are not needed any more.
- Updates user agent to put it in line with Elasticsearch Ruby agent. It now looks like this: `elastic-workplace-search-ruby/0.4.1 (RUBY_VERSION: 2.6.5; linux x86_64)`
- Removes User Agent from configurable values.